### PR TITLE
ci: remove pr capability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Ockam Tag To Update Homebrew To
+        description: Ockam Tag To Update Homebrew To. e.g. ockam_v0.59.0
         required: true
   schedule:
     - cron: '*/10 * * * *'
@@ -12,8 +12,6 @@ on:
 permissions:
   # Allows us write to the repo
   contents: write
-  # Pull request permission
-  pull-requests: write
   # Actions permission allows us cancel workflows.
   actions: write
 
@@ -109,6 +107,3 @@ jobs:
           git add ockam.rb
           git commit -m "Update to release ${{ needs.check_unique.outputs.tag_name }}"
           git push --set-upstream origin $release_name
-
-          gh pr create --title "${{ needs.check_unique.outputs.tag_name }} release" --body "Ockam release"\
-           --base main -H $release_name -r mrinalwadhwa -R build-trust/homebrew-ockam


### PR DESCRIPTION
Remove PR ability in automation. We will have to manually create PR from the generated branch.