### PR TITLE
add git signing and ability to spawn workflows

### DIFF
--- a/.github/workflows/create-release-pull-request.yml
+++ b/.github/workflows/create-release-pull-request.yml
@@ -17,6 +17,7 @@ jobs:
   update_homebrew:
     name: Update Home Brew Version
     runs-on: ubuntu-20.04
+    environment: release
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:

--- a/.github/workflows/create-release-pull-request.yml
+++ b/.github/workflows/create-release-pull-request.yml
@@ -35,6 +35,19 @@ jobs:
           ls
           echo ::set-output name=dir::$temp_dir
 
+      - name: Import GPG key
+        id: import_gpg
+        uses: hashicorp/ghaction-import-gpg@78437f97569a473e42b227be84d4084c2dfb49ba
+        env:
+          GPG_PRIVATE_KEY: '${{ secrets.GPG_PRIVATE_KEY }}'
+          PASSPHRASE: '${{ secrets.GPG_PASSPHRASE }}'
+
+      - name: Add GPG Key
+        run: |
+          git config --global user.email "${{ secrets.GPG_EMAIL }}"
+          git config --global user.name "${{ secrets.GPG_USER_NAME }}"
+          git config --global user.signingkey "${{ steps.import_gpg.outputs.fingerprint }}"
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@536b37ec5d5b543420bdfd9b744c5965bd4d8730
 
@@ -83,11 +96,10 @@ jobs:
           git config --global user.email "bot@ockam.io"
           git config --global user.name "Ockam Bot"
 
-          release_name="${{ github.event.inputs.tag }}_release_$(date +'%s')"
-          git checkout -B $release_name
-          git add ockam.rb
-          git commit -m "Update to release ${{ github.event.inputs.tag }}"
-          git push --set-upstream origin $release_name
+          release_name="release_$(date +'%d-%m-%Y')"
 
-          gh pr create --title "${{ github.event.inputs.tag }} release" --body "Ockam release"\
-           --base main -H $release_name -r mrinalwadhwa
+          # Checkout to release branch
+          git checkout -B ${release_name}
+          git add ockam.rb
+          git commit -S -m "Update to release ${{ github.event.inputs.tag }}"
+          git push --set-upstream origin ${release_name}


### PR DESCRIPTION
This PR adds ability to spawn workflow run when PRs are created by Github Action Bot. We also sign all commits using our Ockam bot GPG key.
Note, we add the following secrets which should be under Github Environment named `release`
- GPG_PRIVATE_KEY: Bots GPG private key
- GPG_PASSPHRASE: Bots GPG passphrase
- GPG_EMAIL: Bots GPG email
- GPG_USER_NAME: Bots GPG username

We also need to allow this action `hashicorp/ghaction-import-gpg`