### PR TITLE
Add shell completions

### DIFF
--- a/.github/ockam.rb.template
+++ b/.github/ockam.rb.template
@@ -12,8 +12,7 @@ class Ockam < Formula
       sha256 "ockam.aarch64-apple-darwin_sha256_value"
 
       def install
-        mv "ockam.aarch64-apple-darwin", "ockam"
-        bin.install "ockam"
+        bin.install "ockam.aarch64-apple-darwin" => "ockam"
       end
     end
 
@@ -22,8 +21,7 @@ class Ockam < Formula
       sha256 "ockam.x86_64-apple-darwin_sha256_value"
 
       def install
-        mv "ockam.x86_64-apple-darwin", "ockam"
-        bin.install "ockam"
+        bin.install "ockam.x86_64-apple-darwin" => "ockam"
       end
     end
   end
@@ -34,8 +32,7 @@ class Ockam < Formula
       sha256 "ockam.aarch64-unknown-linux-musl_sha256_value"
 
       def install
-        mv "ockam.aarch64-unknown-linux-musl", "ockam"
-        bin.install "ockam"
+        bin.install "ockam.aarch64-unknown-linux-musl" => "ockam"
       end
     end
 
@@ -44,8 +41,7 @@ class Ockam < Formula
       sha256 "ockam.x86_64-unknown-linux-musl_sha256_value"
 
       def install
-        mv "ockam.x86_64-unknown-linux-musl", "ockam"
-        bin.install "ockam"
+        bin.install "ockam.x86_64-unknown-linux-musl" => "ockam"
       end
     end
   end

--- a/.github/ockam.rb.template
+++ b/.github/ockam.rb.template
@@ -14,6 +14,7 @@ class Ockam < Formula
       def install
         bin.install "ockam.aarch64-apple-darwin" => "ockam"
         system "chmod", "+x", bin/"ockam"
+        generate_completions_from_executable(bin/"ockam", "completion", "--shell")
       end
     end
 
@@ -24,6 +25,7 @@ class Ockam < Formula
       def install
         bin.install "ockam.x86_64-apple-darwin" => "ockam"
         system "chmod", "+x", bin/"ockam"
+        generate_completions_from_executable(bin/"ockam", "completion", "--shell")
       end
     end
   end
@@ -36,6 +38,7 @@ class Ockam < Formula
       def install
         bin.install "ockam.aarch64-unknown-linux-musl" => "ockam"
         system "chmod", "+x", bin/"ockam"
+        generate_completions_from_executable(bin/"ockam", "completion", "--shell")
       end
     end
 
@@ -46,6 +49,7 @@ class Ockam < Formula
       def install
         bin.install "ockam.x86_64-unknown-linux-musl" => "ockam"
         system "chmod", "+x", bin/"ockam"
+        generate_completions_from_executable(bin/"ockam", "completion", "--shell")
       end
     end
   end

--- a/.github/ockam.rb.template
+++ b/.github/ockam.rb.template
@@ -13,6 +13,7 @@ class Ockam < Formula
 
       def install
         bin.install "ockam.aarch64-apple-darwin" => "ockam"
+        system "chmod", "+x", bin/"ockam"
       end
     end
 
@@ -22,6 +23,7 @@ class Ockam < Formula
 
       def install
         bin.install "ockam.x86_64-apple-darwin" => "ockam"
+        system "chmod", "+x", bin/"ockam"
       end
     end
   end
@@ -33,6 +35,7 @@ class Ockam < Formula
 
       def install
         bin.install "ockam.aarch64-unknown-linux-musl" => "ockam"
+        system "chmod", "+x", bin/"ockam"
       end
     end
 
@@ -42,6 +45,7 @@ class Ockam < Formula
 
       def install
         bin.install "ockam.x86_64-unknown-linux-musl" => "ockam"
+        system "chmod", "+x", bin/"ockam"
       end
     end
   end

--- a/ockam.rb
+++ b/ockam.rb
@@ -12,8 +12,7 @@ class Ockam < Formula
       sha256 "829a534d7d5569a2c9aa18776fa539698bbb474bd27ca5e2814293e29747297c"
 
       def install
-        mv "ockam.aarch64-apple-darwin", "ockam"
-        bin.install "ockam"
+        bin.install "ockam.aarch64-apple-darwin" => "ockam"
       end
     end
 
@@ -22,8 +21,7 @@ class Ockam < Formula
       sha256 "21eee9f2a683390853fb864ab81791fa7e2ba9704c7ea95a73ad1b68c24d2aad"
 
       def install
-        mv "ockam.x86_64-apple-darwin", "ockam"
-        bin.install "ockam"
+        bin.install "ockam.x86_64-apple-darwin" => "ockam"
       end
     end
   end
@@ -34,8 +32,7 @@ class Ockam < Formula
       sha256 "f4a056e01187dac78044bca5f34557b22a1112917ca2b3247a7d866973038413"
 
       def install
-        mv "ockam.aarch64-unknown-linux-musl", "ockam"
-        bin.install "ockam"
+        bin.install "ockam.aarch64-unknown-linux-musl" => "ockam"
       end
     end
 
@@ -44,8 +41,7 @@ class Ockam < Formula
       sha256 "44033bcc9ac384519922247d98876be2c5430cdc1de49b16fa07f59a47829197"
 
       def install
-        mv "ockam.x86_64-unknown-linux-musl", "ockam"
-        bin.install "ockam"
+        bin.install "ockam.x86_64-unknown-linux-musl" => "ockam"
       end
     end
   end

--- a/ockam.rb
+++ b/ockam.rb
@@ -14,6 +14,7 @@ class Ockam < Formula
       def install
         bin.install "ockam.aarch64-apple-darwin" => "ockam"
         system "chmod", "+x", bin/"ockam"
+        generate_completions_from_executable(bin/"ockam", "completion", "--shell")
       end
     end
 
@@ -24,6 +25,7 @@ class Ockam < Formula
       def install
         bin.install "ockam.x86_64-apple-darwin" => "ockam"
         system "chmod", "+x", bin/"ockam"
+        generate_completions_from_executable(bin/"ockam", "completion", "--shell")
       end
     end
   end
@@ -36,6 +38,7 @@ class Ockam < Formula
       def install
         bin.install "ockam.aarch64-unknown-linux-musl" => "ockam"
         system "chmod", "+x", bin/"ockam"
+        generate_completions_from_executable(bin/"ockam", "completion", "--shell")
       end
     end
 
@@ -46,6 +49,7 @@ class Ockam < Formula
       def install
         bin.install "ockam.x86_64-unknown-linux-musl" => "ockam"
         system "chmod", "+x", bin/"ockam"
+        generate_completions_from_executable(bin/"ockam", "completion", "--shell")
       end
     end
   end

--- a/ockam.rb
+++ b/ockam.rb
@@ -13,6 +13,7 @@ class Ockam < Formula
 
       def install
         bin.install "ockam.aarch64-apple-darwin" => "ockam"
+        system "chmod", "+x", bin/"ockam"
       end
     end
 
@@ -22,6 +23,7 @@ class Ockam < Formula
 
       def install
         bin.install "ockam.x86_64-apple-darwin" => "ockam"
+        system "chmod", "+x", bin/"ockam"
       end
     end
   end
@@ -33,6 +35,7 @@ class Ockam < Formula
 
       def install
         bin.install "ockam.aarch64-unknown-linux-musl" => "ockam"
+        system "chmod", "+x", bin/"ockam"
       end
     end
 
@@ -42,6 +45,7 @@ class Ockam < Formula
 
       def install
         bin.install "ockam.x86_64-unknown-linux-musl" => "ockam"
+        system "chmod", "+x", bin/"ockam"
       end
     end
   end


### PR DESCRIPTION
Readd shell completions for Bash, Zsh and Fish.

The reasons [the old way](https://github.com/build-trust/homebrew-ockam/pull/34) of doing this was failing were:
* `Utils.safe_popen_read` was not used (`generate_completions_from_executable` calls this internally)
* the binary was not yet executable. That is taken care of by homebrew after the `install` phase. Doing it earlier like we do now is no extra harm, homebrew makes sure the correct permissions are always set at the end.

Also fixed:
* use [new shorter install syntax](https://github.com/Homebrew/brew/blob/d863d333c7dfab4167c62887a8dfc821c8c3d9f3/Library/Homebrew/formula.rb#L1675)

Worth noting:
* one call to `generate_completions_from_executable` installs completions for all three shells.

Resolves https://github.com/build-trust/ockam/issues/3382