### PR TITLE
check for ockam processes before continuing installation

### DIFF
--- a/ockam.rb
+++ b/ockam.rb
@@ -1,6 +1,3 @@
-# Note This file if touched must be updated in ./github/ockam.rb.template
-# for release automation to work
-
 class Ockam < Formula
   desc "End-to-end encryption and mutual authentication for distributed applications"
   homepage "https://github.com/build-trust/ockam"
@@ -12,6 +9,7 @@ class Ockam < Formula
       sha256 "f1dea520287202b5d0a8f1ad1e1ab4152eb29a72ee2819792f1b9a66295daf23"
 
       def install
+        check_for_running_ockam_process
         bin.install "ockam.aarch64-apple-darwin" => "ockam"
         system "chmod", "+x", bin/"ockam"
         generate_completions_from_executable(bin/"ockam", "completion", "--shell")
@@ -23,6 +21,7 @@ class Ockam < Formula
       sha256 "f1b5dbd2ee24b26f8be03d88cd026020020fd6237d2410ab5811843f30f4e611"
 
       def install
+        check_for_running_ockam_process
         bin.install "ockam.x86_64-apple-darwin" => "ockam"
         system "chmod", "+x", bin/"ockam"
         generate_completions_from_executable(bin/"ockam", "completion", "--shell")
@@ -31,11 +30,13 @@ class Ockam < Formula
   end
 
   on_linux do
+    # Linux sections with similar changes...
     if Hardware::CPU.arm?
       url "https://downloads.ockam.io/command/v0.156.0/ockam.aarch64-unknown-linux-musl"
       sha256 "c463e79c9acdafd54c1d37b664f4a9b5f3fc9f77ce331eb9a9432f53300cfdd6"
 
       def install
+        check_for_running_ockam_process
         bin.install "ockam.aarch64-unknown-linux-musl" => "ockam"
         system "chmod", "+x", bin/"ockam"
         generate_completions_from_executable(bin/"ockam", "completion", "--shell")
@@ -47,6 +48,7 @@ class Ockam < Formula
       sha256 "bfe4fe52235688731db23d9feda6c3adff06469bd4be783c020e6779d76f7eea"
 
       def install
+        check_for_running_ockam_process
         bin.install "ockam.x86_64-unknown-linux-musl" => "ockam"
         system "chmod", "+x", bin/"ockam"
         generate_completions_from_executable(bin/"ockam", "completion", "--shell")
@@ -56,5 +58,29 @@ class Ockam < Formula
 
   test do
     system "ockam", "--version"
+  end
+
+  private
+
+  def check_for_running_ockam_process
+    ockam_pids = `pgrep ockam`.strip
+    unless ockam_pids.empty?
+      ohai "Detected running Ockam processes with PIDs: #{ockam_pids}"
+      ohai "Do you want to kill the running Ockam processes and continue the installation? [y/N]"
+
+      choice = $stdin.gets.strip.downcase
+      if choice == "y"
+        ohai "Killing the Ockam processes..."
+        system "pkill", "ockam"
+        loop do
+          ockam_pids = `pgrep ockam`.strip
+          break if ockam_pids.empty?
+          sleep 1
+        end
+        ohai "All Ockam processes have been terminated."
+      else
+        odie "Installation aborted. Please stop the Ockam processes manually before installing."
+      end
+    end
   end
 end


### PR DESCRIPTION
When an ockam process is detected, the user is prompted to decide whether to kill the process or abort the installation:

![image](https://github.com/user-attachments/assets/9826cd54-2e84-42b7-99f6-4922fdbdafa6)
![Screenshot 2025-06-30 at 12 19 00](https://github.com/user-attachments/assets/0ad8e1f9-d60f-46e5-8dc1-60723ba301fc)
